### PR TITLE
Set proper mode on default_site directory

### DIFF
--- a/tasks/default_site.yml
+++ b/tasks/default_site.yml
@@ -6,7 +6,7 @@
     state: directory
     owner: "{{nginx_user}}"
     group: "{{nginx_user}}"
-    mode: 0644
+    mode: 0754
 
 - name: Nginx | Update the default site configuration
   template:


### PR DESCRIPTION
It needs to be ug+x to be accessible.

Signed-off-by: Jean-Denis Vauguet jd@vauguet.fr
