### PR TITLE
Fixed typo in http_realip.conf.j2

### DIFF
--- a/templates/modules/http_realip.conf.j2
+++ b/templates/modules/http_realip.conf.j2
@@ -1,4 +1,4 @@
-{$ for address in nginx_realip_addresses %}
+{% for address in nginx_realip_addresses %}
 set_real_ip_from {{address}};
 {% endfor %}
 real_ip_header {{nginx_realip_header}};


### PR DESCRIPTION
There was a $ instead of a % causing a failure when including this module.
