### PR TITLE
Upstreams + more flexible parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,20 +101,28 @@ nginx_sites:
       name: foo
       listen: 8080
       server_name: localhost
-      location1:
-        name: "/"
-        try_files: "$uri $uri/ /index.html"
-        sendfile: "on"
+      location:
+        - name: "/"
+          try_files: "$uri $uri/ /index.html"
+          sendfile: "on"
   - server:
-      name: bar
-      listen: 8888
-      server_name: webmail.localhost
-      location1:
-        name: /
-        try_files: "$uri $uri/ /index.html"
-      location2:
-        name: /images/
-        try_files: "$uri $uri/ /index.html"
+     name:
+      - example.org
+      - www.example.org
+      - help.example.org
+
+     listen: 8002
+     location:
+     - name: "/"
+       proxy_pass_header:
+         - "Server"
+       proxy_set_header:
+         - "Host $http_host"
+         - "X-Real-IP $remote_addr"
+         - "X-Scheme $scheme"
+
+       proxy_redirect: "off"
+       proxy_pass: "http://features_service_guaranteed"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Ansible role which installs and configures Nginx, from a package or from source 
 ##### Ansible
 
 It has been tested on Ansible 1.5 and above, and depends on the following roles:
-  - Ansibles.apt
-  - Ansibles.build-essential
-  - Ansibles.perl
-  - Ansibles.monit (if you want monit protection)
+  - pjan.vandaele.apt
+  - pjan.vandaele.build-essential
+  - pjan.vandaele.perl
+  - pjan.vandaele.monit (if you want monit protection)
 
 
 ##### Platforms

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # file: nginx/defaults/main.yml
 
-nginx_install_method: "source"
+nginx_install_method: "package"
 nginx_source_version: "1.5.3"
 
 nginx_user: www-data

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,11 +14,11 @@ galaxy_info:
   - system
 
 dependencies:
-  - Ansibles.hostname
-  - Ansibles.apt
-  - role: Ansibles.build-essential
+  - pjan.vandaele.hostname
+  - pjan.vandaele.apt
+  - role: pjan.vandaele.build-essential
     when: nginx_install_method is defined and nginx_install_method == "source"
-  - role: Ansibles.perl
+  - role: pjan.vandaele.perl
     when: nginx_install_method is defined and nginx_install_method == "source"
-  - role: Ansibles.monit
+  - role: pjan.vandaele.monit
     when: monit_protection is defined and monit_protection == true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,9 +16,9 @@ galaxy_info:
 dependencies:
   - Ansibles.hostname
   - Ansibles.apt
-  # - role: Ansibles.build-essential
-  #   when: nginx_install_method is defined and nginx_install_method == "source"
-  # - role: Ansibles.perl
-  #   when: nginx_install_method is defined and nginx_install_method == "source"
-  # - role: Ansibles.monit
-  #   when: monit_protection is defined and monit_protection == true
+  - role: Ansibles.build-essential
+    when: nginx_install_method is defined and nginx_install_method == "source"
+  - role: Ansibles.perl
+    when: nginx_install_method is defined and nginx_install_method == "source"
+  - role: Ansibles.monit
+    when: monit_protection is defined and monit_protection == true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,9 +16,9 @@ galaxy_info:
 dependencies:
   - Ansibles.hostname
   - Ansibles.apt
-  - role: Ansibles.build-essential
-    when: nginx_install_method is defined and nginx_install_method == "source"
-  - role: Ansibles.perl
-    when: nginx_install_method is defined and nginx_install_method == "source"
-  - role: Ansibles.monit
-    when: monit_protection is defined and monit_protection == true
+  # - role: Ansibles.build-essential
+  #   when: nginx_install_method is defined and nginx_install_method == "source"
+  # - role: Ansibles.perl
+  #   when: nginx_install_method is defined and nginx_install_method == "source"
+  # - role: Ansibles.monit
+  #   when: monit_protection is defined and monit_protection == true

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -93,7 +93,7 @@ http {
 
 {% if nginx_upstreams is defined %}
 {% if nginx_proxy_next_upstream %}
-proxy_next_upstream {{ nginx_proxy_next_upstream }}
+proxy_next_upstream {{ nginx_proxy_next_upstream }};
 
 {% endif %}
 {% for upstream in nginx_upstreams %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -97,7 +97,7 @@ proxy_next_upstream {{ nginx_proxy_next_upstream }};
 
 {% endif %}
 {% for upstream in nginx_upstreams %}
-upstream {
+upstream {{ upstream.name }} {
 {% if upstream.zone is defined %}
   zone {{ upstream.zone.name }} {{upstream.zone.size }};
 {% endif %}

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -48,6 +48,9 @@ http {
   tcp_nopush on;
   tcp_nodelay on;
 
+
+
+
 {% if nginx_keepalive == 'on' %}
   # Timeouts
   keepalive_timeout  {{nginx_keepalive_timeout}};
@@ -86,6 +89,38 @@ http {
 
 {% if nginx_enable_rate_limiting %}
   limit_req_zone $binary_remote_addr zone={{nginx_rate_limiting_zone_name}}:{{nginx_rate_limiting_backoff}} rate={{nginx_rate_limit}};
+{% endif %}
+
+{% if nginx_upstreams is defined %}
+{% if nginx_proxy_next_upstream %}
+proxy_next_upstream {{ nginx_proxy_next_upstream }}
+
+{% endif %}
+{% for upstream in nginx_upstreams %}
+upstream {
+{% if upstream.zone is defined %}
+  zone {{ upstream.zone.name }} {{upstream.zone.size }};
+{% endif %}
+{% if upstream.directives is defined %}
+{% for directive in upstream.directives %}
+  {{ directive }};
+{% endfor %}
+{% endif %}
+{% if upstream.servers is defined %}
+{% for server in upstream.servers %}
+{% set param_strings = [] %}
+{% if server.params is defined %}
+{% for k,v in server.params.iteritems() %}
+{% do param_strings.append("%s=%s"|format(k,v)) %}
+{% endfor %}
+{% endif %}
+  server {{ server['address'] }} {{ param_strings|join(' ') }};
+{% endfor %}
+{% endif %}
+
+}
+
+{% endfor %}
 {% endif %}
 
   include {{nginx_dir}}/conf.d/*.conf;

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -1,7 +1,17 @@
 
 server {
 
-{% for field in item.server.iterkeys()|difference(['location']) %}
+{% if item.server.name is defined %}
+  {% if item.server.name is string %}
+  server_name {{ item.server.name }}
+  {% else %}
+  {% for name in item.server.name %}
+  server_name {{ name }}
+  {% endfor %}
+  {% endif %}
+{% endif %}
+
+{% for field in item.server.iterkeys()|difference(['location', 'name']) %}
 {% if item.server[field] is string or item.server[field] is not iterable %}
   {{ field }} {{ item.server[field] }};
 {% else %}

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -3,10 +3,10 @@ server {
 
 {% if item.server.name is defined %}
   {% if item.server.name is string %}
-  server_name {{ item.server.name }}
+  server_name {{ item.server.name }};
   {% else %}
   {% for name in item.server.name %}
-  server_name {{ name }}
+  server_name {{ name }};
   {% endfor %}
   {% endif %}
 {% endif %}
@@ -35,7 +35,7 @@ server {
 {% endfor %}
   }
 {% if item.server['location'][field] is string %}
-{{ field }}
+{{ field }};
 {% endif %}
 {% endfor %}
 {% endif %}

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -2,13 +2,13 @@
 server {
 
 {% if item.server.name is defined %}
-  {% if item.server.name is string %}
+{% if item.server.name is string %}
   server_name {{ item.server.name }};
-  {% else %}
-  {% for name in item.server.name %}
+{% else %}
+{% for name in item.server.name %}
   server_name {{ name }};
-  {% endfor %}
-  {% endif %}
+{% endfor %}
+{% endif %}
 {% endif %}
 
 {% for field in item.server.iterkeys()|difference(['location', 'name']) %}

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -1,17 +1,32 @@
+
 server {
 
-{% for k,v in item.server.iteritems() %}
-{% if k.find('location') == -1 and k != 'name' %}
-  {{ k }} {{ v }};
+{% for field in item.server.iterkeys()|difference(['location']) %}
+{% if item.server[field] is string or item.server[field] is not iterable %}
+  {{ field }} {{ item.server[field] }};
+{% else %}
+{% for element in item.server[field] %}
+  {{ field }} {{ element }};
+{% endfor %}
 {% endif %}
 {% endfor %}
+{% if item.server['location'] is defined %}
+{% for location_entry in item.server['location'] %}
 
-{% for k,v in item.server.iteritems() if k.find('location') != -1 %}
-  location {{ v.name }} {
-{% for x,y in v.iteritems() if x != 'name' %}
-    {{ x }} {{ y }};
+  location {{ location_entry.name }} {
+{% for field in location_entry.iterkeys()|difference(['name']) %}
+{% if location_entry[field] is string or location_entry[field] is not iterable %}
+    {{ field }} {{ location_entry[field] }};
+{% else %}
+{% for element in location_entry[field] %}
+    {{ field }} {{ element }};
+{% endfor %}
+{% endif %}
 {% endfor %}
   }
+{% if item.server['location'][field] is string %}
+{{ field }}
+{% endif %}
 {% endfor %}
-
+{% endif %}
 }


### PR DESCRIPTION
- Adding support for upstreams. Currently in nginx.conf, a potential improvement would be to put them under upstreams/ and then include that in nginx.conf or something similar.
- Locations are specified as a `location` list
- Server names can be specified as either a string or a list
- Updated templates
