### PR TITLE
add more granular access to access log formats and filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Currently it's been developed for, and tested on Ubuntu. It is assumed to work o
 - `nginx_daemon_disable` - whether the daemon should be disabled which can be set to yes or no
 - `nginx_worker_rlimit_nofile` - used for config value of `worker_rlimit_nofile`. Can replace any "ulimit -n" command. The value depend on your usage (cache or not) but must always be superior than worker_connections. Set to `null` to ignore
 - `nginx_error_log_options` - option flags for the error_log
+- `nginx_error_log_filename` - filename for the error log
 - `nginx_worker_connections` - sets the number of worker connections
 - `nginx_multi_accept` - used for config value of events { multi_accept }. Try to accept() as many connections as possible. Can be set to yes or no
 - `nginx_charset` - used to specify an explicit default charset (say, 'utf-8', 'off'…)
@@ -62,6 +63,14 @@ Currently it's been developed for, and tested on Ubuntu. It is assumed to work o
 - `nginx_rate_limiting_zone_name` - sets the shared memory zone
 - `nginx_rate_limiting_backoff` - sets the maximum burst size of requests
 - `nginx_rate_limit` - sets the rate (e.g. 1r/s)
+- `nginx_access_logs` - a list of access log formats, filenames and options 
+       
+        nginx_access_logs:
+          - name: "main"
+            format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"'
+            options: null
+            filename: "access.log"
+
 
 ##### source
 - `nginx_source_version` - the version of Nginx to install

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,12 +19,12 @@ nginx_worker_processes: 4
 nginx_daemon_disable: no
 nginx_worker_rlimit_nofile: null
 nginx_error_log_options: null
+nginx_error_log_filename: 'error.log'
 nginx_worker_connections: 1024
 nginx_multi_accept: 'on'
 nginx_event: null
 nginx_charset: null
 nginx_disable_access_log: no
-nginx_access_log_options: null
 nginx_server_tokens: null
 nginx_sendfile: 'on'
 nginx_keepalive: "on"
@@ -45,7 +45,11 @@ nginx_enable_rate_limiting: no
 nginx_rate_limiting_zone_name: "default"
 nginx_rate_limiting_backoff: "10m"
 nginx_rate_limit: "1r/s"
-
+nginx_access_logs:
+  - name: "main"
+    format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"'
+    options: null
+    filename: "access.log"
 
 # default site
 nginx_default_root: "{{nginx_www_dir}}/default"

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -7,7 +7,7 @@ daemon off;
 worker_rlimit_nofile {{nginx_worker_rlimit_nofile}};
 {% endif %}
 
-error_log  {{nginx_log_dir}}/error.log{% if nginx_error_log_options %} {{nginx_error_log_options}}{% endif %};
+error_log  {{nginx_log_dir}}/{{nginx_error_log_filename}}{% if nginx_error_log_options %} {{nginx_error_log_options}}{% endif %};
 pid        {{nginx_pid}};
 
 events {
@@ -34,13 +34,13 @@ http {
   charset {{nginx_charset}};
 {% endif %}
 
-  # Use the apache log formatting
-  log_format  main  '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"';
-
 {% if nginx_disable_access_log %}
   access_log    off;
 {% else %}
-  access_log    {{nginx_log_dir}}/access.log{% if nginx_access_log_options %} {{nginx_access_log_options}}{% endif %};
+{% for log in nginx_access_logs %}
+  log_format  {{log['name']}}  {{log['format']}};
+  access_log    {{nginx_log_dir}}/{{log['filename']}} {{log['name']}}{% if log['options'] %} {{log['options']}}{% endif %};
+{% endfor %}
 {% endif %}
 {% if nginx_server_tokens %}
   server_tokens {{nginx_server_tokens}};


### PR DESCRIPTION
Hello,
  I added the ability to change the error log filename and access log filename.  In addition now you can define multiple access logs with different formats and options as in the normal Nginx config.  It does make the logging more complicated if you want to change it but it allows for more compatibility. If you would like this functionality you can pull it.
