### PR TITLE
Fixed daemon path

### DIFF
--- a/templates/nginx.init.j2
+++ b/templates/nginx.init.j2
@@ -11,7 +11,7 @@
 ### END INIT INFO
 
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
-DAEMON={{nginx_source_sbin_pat}}
+DAEMON={{nginx_source_sbin_path}}
 NAME=nginx
 DESC=nginx
 PID={{nginx_pid}}


### PR DESCRIPTION
Since we're compiling nginx with the `--sbin-path` directive, we need to use it into out init configuration.
