### PR TITLE
Avoid recompiling nginx, FIXES #10

### DIFF
--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -22,12 +22,24 @@
 - name: Nginx | Unpack the compressed Nginx source
   command: tar -xvzf /tmp/nginx-{{nginx_source_version}}.tar.gz chdir=/tmp creates=/tmp/nginx-{{nginx_source_version}}/README
 
+- name: Nginx | Write out the version and flags used for the build
+  template:
+    src: .nginx_compilation_flags.j2
+    dest: /usr/local/nginx/.nginx_compilation_flags
+  register: nginx_flags
+
+- name: Kill Nginx (old threads)
+  command: pkill nginx
+  ignore_errors: yes
+  when: nginx_flags.changed
+
 - name: Nginx | Compile the Nginx source
   shell: >
     cd /tmp/nginx-{{nginx_source_version}} &&
     ./configure {{nginx_source_configure_flags}} &&
     make &&
     make install
+  when: nginx_flags.changed
 
 - name: Nginx | Update the symbolic link to the nginx install
   file:

--- a/tasks/source.yml
+++ b/tasks/source.yml
@@ -25,7 +25,7 @@
 - name: Nginx | Write out the version and flags used for the build
   template:
     src: .nginx_compilation_flags.j2
-    dest: /usr/local/nginx/.nginx_compilation_flags
+    dest: "{{nginx_dir}}/.nginx_compilation_flags"
   register: nginx_flags
 
 - name: Kill Nginx (old threads)

--- a/templates/.nginx_compilation_flags.j2
+++ b/templates/.nginx_compilation_flags.j2
@@ -1,0 +1,3 @@
+# This file is used to track the nginx build flags, DO NOT CHANGE MANUALLY
+{{nginx_source_version}}
+{{nginx_source_configure_flags}}


### PR DESCRIPTION
When compiling nginx from source, write out a file that tracks the version and the flags used for compilation, if that template has changed, kill the old nginx threads and recompile nginx, otherwise skip it

Fixes #10 