### PR TITLE
add possibility to enable/disable sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ nginx_sites:
         try_files: "$uri $uri/ /index.html"
 ```
 
+To enable or disable specific sites you can add prior used `server_name` attribute to the variables `nginx_enabled_sites` and `nginx_disabled_sites`.
+
+```yaml
+nginx_enabled_sites:
+  - localhost
+```
+
+```yaml
+nginx_disabled_sites:
+  - webmail.localhost
+```
 
 ##### Monit ?
 You can put Nginx under monit monitoring protection, by setting `monit_protection: yes`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,7 +57,8 @@ nginx_default_root: "{{nginx_www_dir}}/default"
 
 # site inventory
 nginx_sites: []
-
+nginx_enabled_sites: []
+nginx_disabled_sites: []
 
 # source
 nginx_source_url: "http://nginx.org/download/nginx-{{nginx_source_version}}.tar.gz"

--- a/tasks/sites.yml
+++ b/tasks/sites.yml
@@ -6,3 +6,22 @@
     dest: "{{nginx_dir}}/sites-available/{{item.server.name}}"
   with_items: nginx_sites
   when: nginx_sites|lower != 'none'
+
+- name: Nginx | Enable sites
+  file:
+    path: "{{nginx_dir}}/sites-enabled/{{item}}"
+    src: "{{nginx_dir}}/sites-available/{{item}}"
+    state: link
+  with_items: nginx_enabled_sites
+  notify:
+    - reload nginx
+  when: nginx_enabled_sites|lower != 'none'
+
+- name: Nginx | Disable sites
+  file:
+    path: "{{nginx_dir}}/sites-enabled/{{item}}"
+    state: absent
+  with_items: nginx_disabled_sites
+  notify:
+    - reload nginx
+  when: nginx_disabled_sites|lower != 'none'


### PR DESCRIPTION
As already mentioned in #20 I've added the possibility to enable and disable sites.
It should be backward compatible since the old behaviour is not changed.
I've also updated the docs to introduce the use of the variables.

Defaults are set to `[]`
