### PR TITLE
Change the build status to reflect that of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## ANXS - nginx [![Build Status](https://travis-ci.org/ANXS/nginx.png)](https://travis-ci.org/ANXS/nginx)
+## ANXS - nginx [![Build Status](https://travis-ci.org/ANXS/nginx.svg?branch=master)](https://travis-ci.org/ANXS/nginx)
 
 Ansible role which installs and configures Nginx, from a package or from source (including a series of optional modules).
 


### PR DESCRIPTION
Changing the build status to reflect that of master, rather than the most recent build of any branch