### PR TITLE
Update modules when they have changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ nginx_source_modules_included:
   http_real_ip_module: "--with-http_realip_module"
   http_spdy_module: "--with-http_spdy_module"
   http_perl_module: "--with-http_perl_module"
-  naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}"
+  naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
   ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
 ```
 

--- a/README.md
+++ b/README.md
@@ -88,17 +88,17 @@ nginx_source_modules_included:
   http_stub_status_module: "--with-http_stub_status_module"
   http_ssl_module: "--with-http_ssl_module"
   http_gzip_static_module: "--with-http_gzip_static_module"
-  upload_progress_module: "--add-module=/tmp/nginx_upload_progress"
-  headers_more_module: "--add-module=/tmp/nginx_headers_more"
-  http_auth_request_module: "--add-module=/tmp/nginx_auth_request"
-  http_echo_module: "--add-module=/tmp/nginx_echo"
+  upload_progress_module: "--add-module=/tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}"
+  headers_more_module: "--add-module=/tmp/headers-more-nginx-module-{{nginx_headers_more_version}}"
+  http_auth_request_module: "--add-module=/tmp/ngx_http_auth_request_module-{{nginx_auth_request_release}}"
+  http_echo_module: "--add-module=/tmp/echo-nginx-module-{{nginx_echo_version}}"
   google_perftools_module: "--with-google_perftools_module"
   ipv6_module: "--with-ipv6"
   http_real_ip_module: "--with-http_realip_module"
   http_spdy_module: "--with-http_spdy_module"
   http_perl_module: "--with-http_perl_module"
-  naxsi_module: "--add-module=/tmp/nginx_naxsi"
-  ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed"
+  naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}"
+  ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
 ```
 
 ##### Sites

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -80,7 +80,7 @@ nginx_source_modules_included:
   http_real_ip_module: "--with-http_realip_module"
   http_spdy_module: "--with-http_spdy_module"
   http_perl_module: "--with-http_perl_module"
-  naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}"
+  naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
   ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
 
 nginx_source_modules_excluded:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,17 +71,17 @@ nginx_source_modules_included:
   http_stub_status_module: "--with-http_stub_status_module"
   http_ssl_module: "--with-http_ssl_module"
   http_gzip_static_module: "--with-http_gzip_static_module"
-  upload_progress_module: "--add-module=/tmp/nginx_upload_progress"
-  headers_more_module: "--add-module=/tmp/nginx_headers_more"
-  http_auth_request_module: "--add-module=/tmp/nginx_auth_request"
-  http_echo_module: "--add-module=/tmp/nginx_echo"
+  upload_progress_module: "--add-module=/tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}"
+  headers_more_module: "--add-module=/tmp/headers-more-nginx-module-{{nginx_headers_more_version}}"
+  http_auth_request_module: "--add-module=/tmp/ngx_http_auth_request_module-{{nginx_auth_request_release}}"
+  http_echo_module: "--add-module=/tmp/echo-nginx-module-{{nginx_echo_version}}"
   google_perftools_module: "--with-google_perftools_module"
   ipv6_module: "--with-ipv6"
   http_real_ip_module: "--with-http_realip_module"
   http_spdy_module: "--with-http_spdy_module"
   http_perl_module: "--with-http_perl_module"
-  naxsi_module: "--add-module=/tmp/nginx_naxsi"
-  ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed"
+  naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}"
+  ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
 
 nginx_source_modules_excluded:
   - mail_pop3_module

--- a/tasks/modules/headers_more_module.yml
+++ b/tasks/modules/headers_more_module.yml
@@ -5,9 +5,11 @@
   get_url:
     url: "{{nginx_headers_more_url}}"
     dest: "/tmp/nginx-headers-more-module-{{nginx_headers_more_version}}.tar.gz"
+  register: nginx_headers_more_download
 
 - name: Nginx | Modules | Unpack the headers_more_module source
   command: tar -xvzf /tmp/nginx-headers-more-module-{{nginx_headers_more_version}}.tar.gz chdir=/tmp creates=/tmp/headers-more-nginx-module-{{nginx_headers_more_version}}
 
 - name: Nginx | Modules | Copy the headers_more_module source folder
-  command: sudo cp -R /tmp/headers-more-nginx-module-{{nginx_headers_more_version}} /tmp/nginx_headers_more creates=/tmp/nginx_headers_more
+  command: sudo cp -R /tmp/headers-more-nginx-module-{{nginx_headers_more_version}} /tmp/nginx_headers_more
+  when: nginx_headers_more_download|changed

--- a/tasks/modules/headers_more_module.yml
+++ b/tasks/modules/headers_more_module.yml
@@ -5,11 +5,7 @@
   get_url:
     url: "{{nginx_headers_more_url}}"
     dest: "/tmp/nginx-headers-more-module-{{nginx_headers_more_version}}.tar.gz"
-  register: nginx_headers_more_download
 
 - name: Nginx | Modules | Unpack the headers_more_module source
-  command: tar -xvzf /tmp/nginx-headers-more-module-{{nginx_headers_more_version}}.tar.gz chdir=/tmp creates=/tmp/headers-more-nginx-module-{{nginx_headers_more_version}}
-
-- name: Nginx | Modules | Copy the headers_more_module source folder
-  command: sudo cp -R /tmp/headers-more-nginx-module-{{nginx_headers_more_version}} /tmp/nginx_headers_more
-  when: nginx_headers_more_download|changed
+  command: tar -xvzf /tmp/nginx-headers-more-module-{{nginx_headers_more_version}}.tar.gz
+    chdir=/tmp creates=/tmp/headers-more-nginx-module-{{nginx_headers_more_version}}

--- a/tasks/modules/http_auth_request_module.yml
+++ b/tasks/modules/http_auth_request_module.yml
@@ -5,10 +5,11 @@
   get_url:
     url: "{{nginx_auth_request_url}}"
     dest: "/tmp/nginx-auth-request-module.tar.gz"
+  register: nginx_auth_request_download
 
 - name: Nginx | Modules | Unpack the http_auth_request_module source
   command: tar -xvzf /tmp/nginx-auth-request-module.tar.gz chdir=/tmp creates=/tmp/ngx_http_auth_request_module-{{nginx_auth_request_release}}
 
 - name: Nginx | Modules | Copy the http_auth_request_module source folder
-  command: sudo cp -R /tmp/ngx_http_auth_request_module-{{nginx_auth_request_release}} /tmp/nginx_auth_request creates=/tmp/nginx_auth_request
-
+  command: sudo cp -R /tmp/ngx_http_auth_request_module-{{nginx_auth_request_release}} /tmp/nginx_auth_request
+  wheb: nginx_auth_request_download|changed

--- a/tasks/modules/http_auth_request_module.yml
+++ b/tasks/modules/http_auth_request_module.yml
@@ -5,11 +5,6 @@
   get_url:
     url: "{{nginx_auth_request_url}}"
     dest: "/tmp/nginx-auth-request-module.tar.gz"
-  register: nginx_auth_request_download
 
 - name: Nginx | Modules | Unpack the http_auth_request_module source
   command: tar -xvzf /tmp/nginx-auth-request-module.tar.gz chdir=/tmp creates=/tmp/ngx_http_auth_request_module-{{nginx_auth_request_release}}
-
-- name: Nginx | Modules | Copy the http_auth_request_module source folder
-  command: sudo cp -R /tmp/ngx_http_auth_request_module-{{nginx_auth_request_release}} /tmp/nginx_auth_request
-  wheb: nginx_auth_request_download|changed

--- a/tasks/modules/http_echo_module.yml
+++ b/tasks/modules/http_echo_module.yml
@@ -5,11 +5,6 @@
   get_url:
     url: "{{nginx_echo_url}}"
     dest: "/tmp/nginx-echo-module.tar.gz"
-  register: nginx_echo_download
 
 - name: Nginx | Modules | Unpack the http_echo_module source
   command: tar -xvzf /tmp/nginx-echo-module.tar.gz chdir=/tmp creates=/tmp/echo-nginx-module-{{nginx_echo_version}}
-
-- name: Nginx | Modules | Copy the http_echo_module source folder
-  command: sudo cp -R /tmp/echo-nginx-module-{{nginx_echo_version}} /tmp/nginx_echo
-  when: nginx_echo_download|changed

--- a/tasks/modules/http_echo_module.yml
+++ b/tasks/modules/http_echo_module.yml
@@ -5,9 +5,11 @@
   get_url:
     url: "{{nginx_echo_url}}"
     dest: "/tmp/nginx-echo-module.tar.gz"
+  register: nginx_echo_download
 
 - name: Nginx | Modules | Unpack the http_echo_module source
   command: tar -xvzf /tmp/nginx-echo-module.tar.gz chdir=/tmp creates=/tmp/echo-nginx-module-{{nginx_echo_version}}
 
 - name: Nginx | Modules | Copy the http_echo_module source folder
-  command: sudo cp -R /tmp/echo-nginx-module-{{nginx_echo_version}} /tmp/nginx_echo creates=/tmp/nginx_echo
+  command: sudo cp -R /tmp/echo-nginx-module-{{nginx_echo_version}} /tmp/nginx_echo
+  when: nginx_echo_download|changed

--- a/tasks/modules/naxsi_module.yml
+++ b/tasks/modules/naxsi_module.yml
@@ -5,12 +5,14 @@
   get_url:
     url: "{{nginx_naxsi_url}}"
     dest: "/tmp/nginx-naxsi-module.tar.gz"
+  register: nginx_naxsi_download
 
 - name: Nginx | Modules | Unpack the naxsi_module source
   command: tar -xvzf /tmp/nginx-naxsi-module.tar.gz chdir=/tmp creates=/tmp/naxsi-{{nginx_naxsi_version}}
 
 - name: Nginx | Modules | Copy the naxsi_module source folder
-  command: sudo cp -R /tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src /tmp/nginx_naxsi creates=/tmp/nginx_naxsi
+  command: sudo cp -R /tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src /tmp/nginx_naxsi
+  when: nginx_naxsi_download|changed
 
 - name: Nginx | Modules | Make sure the naxsi_module configuration is up to date
   copy:

--- a/tasks/modules/naxsi_module.yml
+++ b/tasks/modules/naxsi_module.yml
@@ -5,14 +5,9 @@
   get_url:
     url: "{{nginx_naxsi_url}}"
     dest: "/tmp/nginx-naxsi-module.tar.gz"
-  register: nginx_naxsi_download
 
 - name: Nginx | Modules | Unpack the naxsi_module source
   command: tar -xvzf /tmp/nginx-naxsi-module.tar.gz chdir=/tmp creates=/tmp/naxsi-{{nginx_naxsi_version}}
-
-- name: Nginx | Modules | Copy the naxsi_module source folder
-  command: sudo cp -R /tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src /tmp/nginx_naxsi
-  when: nginx_naxsi_download|changed
 
 - name: Nginx | Modules | Make sure the naxsi_module configuration is up to date
   copy:

--- a/tasks/modules/naxsi_module.yml
+++ b/tasks/modules/naxsi_module.yml
@@ -1,5 +1,5 @@
 # file: roles/nginx/tasks/modules/naxsi_module.yml
-# configure flag: --add-module=/tmp/nginx_naxsi
+# configure flag: --add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src
 
 - name: Nginx | Modules | Download the naxsi_module source
   get_url:

--- a/tasks/modules/ngx_pagespeed.yml
+++ b/tasks/modules/ngx_pagespeed.yml
@@ -1,5 +1,5 @@
 # file: nginx/tasks/modules/ngx_pagespeed.yml
-# configure flag: --add-module=/tmp/ngx_pagespeed
+# configure flag: --add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta
 
 - name: Nginx | Modules | Make sure the dependences are installed
   apt:
@@ -13,25 +13,20 @@
   get_url:
     url: "https://github.com/pagespeed/ngx_pagespeed/archive/release-{{nginx_ngx_pagespeed_version}}-beta.tar.gz"
     dest: "/tmp/ngx_pagespeed_module.tar.gz"
-  register: ngx_pagespeed_download
 
 - name: Nginx | Modules | Unpack the ngx_pagespeed source
   command: tar -xvzf /tmp/ngx_pagespeed_module.tar.gz
   args:
     chdir: /tmp
-    creates: "ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
-
-- name: Nginx | Modules | Copy the ngx_pagespeed source folder
-  command: sudo cp -R /tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta /tmp/ngx_pagespeed
-  when: ngx_pagespeed_download|changed
+    creates: "/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
 
 - name: Nginx | Modules | Download the psol source
   get_url:
     url: "https://dl.google.com/dl/page-speed/psol/{{nginx_ngx_pagespeed_version}}.tar.gz"
-    dest: "/tmp/ngx_pagespeed/psol.tar.gz"
+    dest: "/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta/psol.tar.gz"
 
 - name: Nginx | Modules | Unpack the psol source
-  command: "tar -xvzf /tmp/ngx_pagespeed/psol.tar.gz"
+  command: "tar -xvzf /tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta/psol.tar.gz"
   args:
-    chdir: "/tmp/ngx_pagespeed"
-    creates: "/tmp/ngx_pagespeed/psol"
+    chdir: "/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
+    creates: "/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta/psol"

--- a/tasks/modules/ngx_pagespeed.yml
+++ b/tasks/modules/ngx_pagespeed.yml
@@ -23,7 +23,7 @@
 
 - name: Nginx | Modules | Copy the ngx_pagespeed source folder
   command: sudo cp -R /tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta /tmp/ngx_pagespeed
-  when: ngx_pagespeed_download.changed
+  when: ngx_pagespeed_download|changed
 
 - name: Nginx | Modules | Download the psol source
   get_url:

--- a/tasks/modules/upload_progress_module.yml
+++ b/tasks/modules/upload_progress_module.yml
@@ -7,15 +7,9 @@
   get_url:
     url: "{{nginx_upload_progress_url}}"
     dest: "/tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}.tar.gz"
-  register: nginx_upload_progress_download
 
 - name: Nginx | Modules | Unpack the upload_progress_module source
   command: tar -xvzf /tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}.tar.gz chdir=/tmp creates=/tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}
-  when: nginx_upload_progress_download|changed
-
-- name: Nginx | Modules | Copy the upload_progress_module source folder
-  command: sudo cp -R /tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}} /tmp/nginx_upload_progress
-  when: nginx_upload_progress_download|changed
 
 - name: Nginx | Modules | Make sure the upload_progress_module configuration is updated
   template:

--- a/tasks/modules/upload_progress_module.yml
+++ b/tasks/modules/upload_progress_module.yml
@@ -7,12 +7,15 @@
   get_url:
     url: "{{nginx_upload_progress_url}}"
     dest: "/tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}.tar.gz"
+  register: nginx_upload_progress_download
 
 - name: Nginx | Modules | Unpack the upload_progress_module source
   command: tar -xvzf /tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}.tar.gz chdir=/tmp creates=/tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}}
+  when: nginx_upload_progress_download|changed
 
 - name: Nginx | Modules | Copy the upload_progress_module source folder
-  command: sudo cp -R /tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}} /tmp/nginx_upload_progress creates=/tmp/nginx_upload_progress
+  command: sudo cp -R /tmp/nginx-upload-progress-module-{{nginx_upload_progress_version}} /tmp/nginx_upload_progress
+  when: nginx_upload_progress_download|changed
 
 - name: Nginx | Modules | Make sure the upload_progress_module configuration is updated
   template:


### PR DESCRIPTION
When reading through the nginx module unpacking, and also seeing a commit from @otakup0pe I noticed we are not updating modules when they change (because of the `creates` arg)

Changing this behaviour so that downloaded nginx modules are used from their extracted location, (which has a version number in it) so if a module version changes, a new one is downloaded, and nginx is recompiled using the newly extracted module (rather than the old one, or a combination of old and new)