### PR TITLE
Cant Complie nginx from source with pagespeed module

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ nginx_source_modules_included:
   http_spdy_module: "--with-http_spdy_module"
   http_perl_module: "--with-http_perl_module"
   naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
-  ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
+  # ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta" # Not currently working
 ```
 
 ##### Sites

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,7 +82,7 @@ nginx_source_modules_included:
   http_spdy_module: "--with-http_spdy_module"
   http_perl_module: "--with-http_perl_module"
   naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
-  ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
+  #ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta" # Not currently working
 
 nginx_source_modules_excluded:
   - mail_pop3_module


### PR DESCRIPTION
There appears to be a problem compiling from source and using the pagespeed module, I have removed the flag from the defaults and commented it out on the readme until I am able to figure out why nginx cannot compile properly, the error I get is:
```
...
adding module in /tmp/ngx_pagespeed-1.8.31.4-beta
mod_pagespeed_dir=/tmp/ngx_pagespeed-1.8.31.4-beta/psol/include
build_from_source=false
checking for psol ... not found
./configure: error: module ngx_pagespeed requires the pagespeed optimization library.
Look in obj/autoconf.err for more details
```
If people still want to use the pagespeed module, and are able to get it working, they can add the flag in themselves and the pagespeed module and psol code will be downloaded.. before compilation.

If you are able to get nginx compiled using version `1.8.31.4` of pagespeed and psol, please let me know, as it must just be me doing something silly 