### PR TITLE
Update access_log configuration options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,5 @@ script:
     | grep -q 'changed=0.*failed=0'
     && (echo 'Idempotence test: pass' && exit 0)
     || (echo 'Idempotence test: fail' && exit 1)
+after_failure:
+  - cat /etc/nginx/nginx.conf

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Currently it's been developed for, and tested on Ubuntu. It is assumed to work o
             format: '$remote_addr - $remote_user [$time_local] "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"'
             options: null
             filename: "access.log"
+
+        #This will generate access_log /var/log/nginx/access.log combined
+        nginx_access_logs:
+          - name: "combined"
+            filename: "access.log"
+
 - `nginx_default_root` - the directory to place the default site
 - `nginx_default_enable` - whether or not to actually enable the defaul site
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -38,8 +38,10 @@ http {
   access_log    off;
 {% else %}
 {% for log in nginx_access_logs %}
+{% if 'format' in log %}
   log_format  {{log['name']}}  {{log['format']}};
-  access_log    {{nginx_log_dir}}/{{log['filename']}} {{log['name']}}{% if log['options'] %} {{log['options']}}{% endif %};
+{% endif %}
+  access_log    {{nginx_log_dir}}/{{log['filename']}} {{log['name']}}{% if 'options' in log and log['options']|lower != 'none' %} {{log['options']}}{% endif %};
 {% endfor %}
 {% endif %}
 {% if nginx_server_tokens %}


### PR DESCRIPTION
Under `nginx_access_logs` option,
- If `format` is not defined, do not output `log_format`
- If `options` is not defined, do not output anything

This allows the following configuration 
```
nginx_access_logs:
  - name: "combined"
    filename: "access.log"
```
to generate a line like this:

`access_log    /var/log/nginx/access.log combined`