### PR TITLE
Update defined openssl_version form 1.0.2c to 1.0.2d

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -164,4 +164,4 @@ nginx_naxsi_url: "https://github.com/nbs-system/naxsi/archive/{{nginx_naxsi_vers
 nginx_ngx_pagespeed_version: 1.9.32.3
 
 # OpenSSL configuration
-openssl_version: "1.0.2c"
+openssl_version: "1.0.2d"


### PR DESCRIPTION
The older version is not available anymore what caused an error
by executing the task "extract openssl source" because of missing
resource.