### PR TITLE
update the apt cache before installing packages

### DIFF
--- a/test.yml
+++ b/test.yml
@@ -6,6 +6,7 @@
       apt:
         pkg: "{{item}}"
         state: present
+        update_cache: yes
       with_items: ["perl", "libperl-dev", "monit", "build-essential"]
     - include: 'tasks/main.yml'
     - name: Nginx | Check if nginx is available


### PR DESCRIPTION
If not updating the cache, installation of dependencies failed.

```
vagrant up
Bringing machine 'anxs' up with 'virtualbox' provider...
==> anxs: Importing base box 'ubuntu/trusty64'...
==> anxs: Matching MAC address for NAT networking...
==> anxs: Checking if box 'ubuntu/trusty64' is up to date...
==> anxs: A newer version of the box 'ubuntu/trusty64' is available! You currently
==> anxs: have version '14.04'. The latest is version '20150818.0.0'. Run
==> anxs: `vagrant box update` to update.
==> anxs: Setting the name of the VM: nginx_anxs_1440840845613_60902
==> anxs: Clearing any previously set forwarded ports...
==> anxs: Fixed port collision for 22 => 2222. Now on port 2200.
==> anxs: Clearing any previously set network interfaces...
==> anxs: Preparing network interfaces based on configuration...
    anxs: Adapter 1: nat
    anxs: Adapter 2: hostonly
==> anxs: Forwarding ports...
    anxs: 22 => 2200 (adapter 1)
==> anxs: Booting VM...
==> anxs: Waiting for machine to boot. This may take a few minutes...
    anxs: SSH address: 127.0.0.1:2200
    anxs: SSH username: vagrant
    anxs: SSH auth method: private key
    anxs: Warning: Connection timeout. Retrying...
    anxs: Warning: Remote connection disconnect. Retrying...
    anxs:
    anxs: Vagrant insecure key detected. Vagrant will automatically replace
    anxs: this with a newly generated keypair for better security.
    anxs:
    anxs: Inserting generated public key within guest...
    anxs: Removing insecure key from the guest if its present...
    anxs: Key inserted! Disconnecting and reconnecting using new SSH key...
==> anxs: Machine booted and ready!
==> anxs: Checking for guest additions in VM...
==> anxs: Setting hostname...
==> anxs: Configuring and enabling network interfaces...
==> anxs: Mounting shared folders...
    anxs: /vagrant => /Volumes/Projects/nginx
==> anxs: Running provisioner: ansible...
PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_HOST_KEY_CHECKING=false ANSIBLE_SSH_ARGS='-o UserKnownHostsFile=/dev/null -o ControlMaster=auto -o ControlPersist=60s' ansible-playbook --private-key=/Volumes/Projects/nginx/.vagrant/machines/anxs/virtualbox/private_key --user=vagrant --connection=ssh --limit='anxs' --inventory-file=vagrant-inventory --extra-vars={"nginx_install_method":"source"} --sudo test.yml

PLAY [all] ********************************************************************

GATHERING FACTS ***************************************************************
ok: [anxs.local]

TASK: [install the dependencies] **********************************************
failed: [anxs.local] => (item=perl,libperl-dev,monit,build-essential) => {"failed": true, "item": "perl,libperl-dev,monit,build-essential"}
stderr: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/d/dpkg/libdpkg-perl_1.17.5ubuntu5.3_all.deb  404  Not Found [IP: 91.189.91.24 80]

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/d/dpkg/dpkg-dev_1.17.5ubuntu5.3_all.deb  404  Not Found [IP: 91.189.91.24 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

stdout: Reading package lists...
Building dependency tree...
Reading state information...
The following extra packages will be installed:
  dpkg-dev g++ g++-4.8 libalgorithm-diff-perl libalgorithm-diff-xs-perl
  libalgorithm-merge-perl libdpkg-perl libfile-fcntllock-perl libperl5.18
  libstdc++-4.8-dev
Suggested packages:
  debian-keyring g++-multilib g++-4.8-multilib gcc-4.8-doc libstdc++6-4.8-dbg
  libstdc++-4.8-doc exim4 postfix mail-transport-agent
The following NEW packages will be installed:
  build-essential dpkg-dev g++ g++-4.8 libalgorithm-diff-perl
  libalgorithm-diff-xs-perl libalgorithm-merge-perl libdpkg-perl
  libfile-fcntllock-perl libperl-dev libperl5.18 libstdc++-4.8-dev monit
0 upgraded, 13 newly installed, 0 to remove and 0 not upgraded.
Need to get 11.7 MB of archives.
After this operation, 47.2 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu/ trusty/main libstdc++-4.8-dev amd64 4.8.2-19ubuntu1 [1,050 kB]
Get:2 http://archive.ubuntu.com/ubuntu/ trusty/main g++-4.8 amd64 4.8.2-19ubuntu1 [7,038 kB]
Get:3 http://archive.ubuntu.com/ubuntu/ trusty/main g++ amd64 4:4.8.2-1ubuntu6 [1,490 B]
Err http://archive.ubuntu.com/ubuntu/ trusty-updates/main libdpkg-perl all 1.17.5ubuntu5.3
  404  Not Found [IP: 91.189.91.14 80]
Get:4 http://archive.ubuntu.com/ubuntu/ trusty/main build-essential amd64 11.6ubuntu6 [4,838 B]
Get:5 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-perl all 1.19.02-3 [50.0 kB]
Get:6 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-diff-xs-perl amd64 0.04-2build4 [12.6 kB]
Get:7 http://archive.ubuntu.com/ubuntu/ trusty/main libalgorithm-merge-perl all 0.08-2 [12.7 kB]
Get:8 http://archive.ubuntu.com/ubuntu/ trusty/main libfile-fcntllock-perl amd64 0.14-2build1 [15.9 kB]
Get:9 http://archive.ubuntu.com/ubuntu/ trusty/main libperl5.18 amd64 5.18.2-2ubuntu1 [1,322 B]
Get:10 http://archive.ubuntu.com/ubuntu/ trusty/main libperl-dev amd64 5.18.2-2ubuntu1 [2,274 kB]
Err http://security.ubuntu.com/ubuntu/ trusty-security/main libdpkg-perl all 1.17.5ubuntu5.3
  404  Not Found [IP: 91.189.91.24 80]
Err http://security.ubuntu.com/ubuntu/ trusty-security/main dpkg-dev all 1.17.5ubuntu5.3
  404  Not Found [IP: 91.189.91.24 80]
Get:11 http://archive.ubuntu.com/ubuntu/ trusty/universe monit amd64 1:5.6-2 [286 kB]
Fetched 10.7 MB in 29s (369 kB/s)

msg: '/usr/bin/apt-get -y -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold"   install 'libperl-dev' 'monit' 'build-essential'' failed: E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/d/dpkg/libdpkg-perl_1.17.5ubuntu5.3_all.deb  404  Not Found [IP: 91.189.91.24 80]

E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/d/dpkg/dpkg-dev_1.17.5ubuntu5.3_all.deb  404  Not Found [IP: 91.189.91.24 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?


FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/Users/felix/test.retry

anxs.local                 : ok=1    changed=0    unreachable=0    failed=1

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```