### PR TITLE
Fix #28. Allow directives with the same name.

### DIFF
--- a/templates/site.j2
+++ b/templates/site.j2
@@ -2,14 +2,26 @@ server {
 
 {% for k,v in item.server.iteritems() %}
 {% if k.find('location') == -1 and k != 'name' %}
+{% if v is not string and v is iterable %}
+{% for lv in v %}
+  {{ k }} {{ lv }};
+{% endfor %}
+{% else %}
   {{ k }} {{ v }};
+{% endif %}
 {% endif %}
 {% endfor %}
 
 {% for k,v in item.server.iteritems() if k.find('location') != -1 %}
   location {{ v.name }} {
 {% for x,y in v.iteritems() if x != 'name' %}
+{% if y is not string and y is iterable %}
+{% for ly in y %}
+    {{ x }} {{ ly }};
+{% endfor %}
+{% else %}
     {{ x }} {{ y }};
+{% endif %}
 {% endfor %}
   }
 {% endfor %}


### PR DESCRIPTION
It's the first time that I use the Jinja2 template system, so I'm not really sure about the correctness of this fix.

I wanted to reuse multiple directives with the same name, much like specified in #28 
e.g.:

```
- server:
  listen: '[::]:443 ssl'
  listen: '443 ssl'
  location1: 
    name: /
    proxy_set_header: X-Real-IP $remote_addr
    proxy_set_header: Upgrade $http_upgrade
    proxy_set_header: Connection $connection_upgrade
```

However this doesn't work.

With this PR (that might need testing by someone with more experience than me) the following should work:

```
- server:
  listen:
    - '[::]:443 ssl'
    - '443 ssl'
  location1: 
    name: /
    proxy_set_header: 
      - 'X-Real-IP $remote_addr'
      - 'Upgrade $http_upgrade'
      - 'Connection $connection_upgrade'
```
