### PR TITLE
Added paramerts for selecting nginx apt package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 nginx_install_method: "source"
 nginx_source_version: "1.8.0"
 nginx: "nginx"
+nginx_package_name: "nginx"
 
 nginx_user: www-data
 nginx_group: www-data

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,6 @@
 nginx_install_method: "source"
 nginx_source_version: "1.8.0"
 nginx: "nginx"
-nginx_package_name: "nginx"
 
 nginx_user: www-data
 nginx_group: www-data

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -11,7 +11,7 @@
 
 - name: Nginx | Make sure nginx is installed (package)
   apt:
-    pkg: nginx
+    pkg: "{{nginx_package_name}}"
     state: present
   notify:
     - restart nginx

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -11,7 +11,7 @@
 
 - name: Nginx | Make sure nginx is installed (package)
   apt:
-    pkg: "{{nginx_package_name}}"
+    pkg: "{{nginx}}"
     state: present
   notify:
     - restart nginx


### PR DESCRIPTION
The current package playbook installs the standard nginx package only. The proposed changes would allow for selecting alternative nginx packages: nginx-light, -extras of -full.

A sample playbook installing the nginx-full package

```
- hosts: localhost
  vars_files:
    - defaults/main.yml
  tasks:
    - include: tasks/main.yml
      vars:
        nginx_package_name: "nginx-full"
        nginx_install_method: "package"
```