### PR TITLE
Adds suport to the fastcgi_cache_purge module

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ nginx_source_modules_included:
   http_perl_module: "--with-http_perl_module"
   naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
   ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
+  ngx_cache_purge: "--add-module=/tmp/ngx_cache_purge-{{ngx_cache_purge_version}}"
   geopip: "--with-http_geoip_module"
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -146,6 +146,11 @@ nginx_headers_more_version: "0.261"
 nginx_headers_more_url: "https://github.com/agentzh/headers-more-nginx-module/archive/v{{nginx_headers_more_version}}.tar.gz"
 
 
+# ngx_cache_purge configuration
+ngx_cache_purge_version: "2.3"
+ngx_cache_purge_url: "http://labs.frickle.com/files/ngx_cache_purge-{{ngx_cache_purge_version}}.tar.gz"
+
+
 # http_auth_request_module configuration
 nginx_auth_request_release: "662785733552"
 nginx_auth_request_url: "http://mdounin.ru/hg/ngx_http_auth_request_module/archive/{{nginx_auth_request_release}}.tar.gz"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -84,6 +84,7 @@ nginx_source_modules_included:
   http_perl_module: "--with-http_perl_module"
   naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
   ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
+  ngx_cache_purge: "--add-module=/tmp/ngx_cache_purge-{{ngx_cache_purge_version}}"
   http_geoip_module: "--with-http_geoip_module"
 
 nginx_source_modules_excluded:

--- a/tasks/modules.yml
+++ b/tasks/modules.yml
@@ -41,3 +41,6 @@
 
 - include: modules/http_geoip_module.yml
   when: nginx_source_modules_included.http_geoip_module is defined
+
+- include: modules/ngx_cache_purge.yml
+  when: nginx_source_modules_included.ngx_cache_purge is defined

--- a/tasks/modules/ngx_cache_purge.yml
+++ b/tasks/modules/ngx_cache_purge.yml
@@ -1,0 +1,11 @@
+# file: nginx/tasks/modules/ngx_cache_purge.yml
+# configure flag: --add-module=/tmp/ngx_cache_purge
+
+- name: Nginx | Modules | Download the ngx_cache_purge source
+  get_url:
+    url: "{{ngx_cache_purge_url}}"
+    dest: "/tmp/ngx_cache_purge-{{ngx_cache_purge_version}}.tar.gz"
+
+- name: Nginx | Modules | Unpack the ngx_cache_purge source
+  command: tar -xvzf /tmp/ngx_cache_purge-{{ngx_cache_purge_version}}.tar.gz
+    chdir=/tmp creates=/tmp/ngx_cache_purge-{{ngx_cache_purge_version}}


### PR DESCRIPTION
Adds the ```ngx_cache_purge``` to the list of included modules.  
This module is very useful to wordpress installs, and is often used together with the plugin nginx-helper.