### PR TITLE
nginx_sites was being read as a literal rather than a var.

### DIFF
--- a/tasks/sites.yml
+++ b/tasks/sites.yml
@@ -4,7 +4,7 @@
   template:
     src: site.j2
     dest: "{{nginx_dir}}/sites-available/{{item.server.name}}"
-  with_items: nginx_sites
+  with_items: "{{nginx_sites}}"
   when: nginx_sites|lower != 'none'
   notify:
     - reload nginx
@@ -16,14 +16,14 @@
     owner: "{{nginx_user}}"
     group: "{{nginx_user}}"
     mode: 0755
-  with_items: nginx_sites
+  with_items: "{{nginx_sites}}"
 
 - name: Nginx | Enable sites
   file:
     path: "{{nginx_dir}}/sites-enabled/{{item}}"
     src: "{{nginx_dir}}/sites-available/{{item}}"
     state: link
-  with_items: nginx_enabled_sites
+  with_items: "{{nginx_enabled_sites}}"
   notify:
     - reload nginx
   when: nginx_enabled_sites|lower != 'none'
@@ -32,7 +32,7 @@
   file:
     path: "{{nginx_dir}}/sites-enabled/{{item}}"
     state: absent
-  with_items: nginx_disabled_sites
+  with_items: "{{nginx_disabled_sites}}"
   notify:
     - reload nginx
   when: nginx_disabled_sites|lower != 'none'


### PR DESCRIPTION
I'm new to Ansible but it seems this was a syntax change that happened somewhere ~`2.x`.