### PR TITLE
Add nginx-rtmp-module

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ nginx_source_modules_included:
   naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
   ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
   http_geoip_module: "--with-http_geoip_module"
+  nginx_rtmp_module: "--add-module=/tmp/nginx-rtmp-module-{{nginx_rtmp_version}}"
 ```
 
 ##### Sites
@@ -206,7 +207,7 @@ To the contributors:
 
 
 #### Testing
-This project comes with a VagrantFile, this is a fast and easy way to test changes to the role, fire it up with `vagrant up`. 
+This project comes with a VagrantFile, this is a fast and easy way to test changes to the role, fire it up with `vagrant up`.
 
 See [vagrant docs](https://docs.vagrantup.com/v2/) for getting setup with vagrant
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,7 @@ nginx_source_modules_included:
   naxsi_module: "--add-module=/tmp/naxsi-{{nginx_naxsi_version}}/naxsi_src"
   ngx_pagespeed: "--add-module=/tmp/ngx_pagespeed-release-{{nginx_ngx_pagespeed_version}}-beta"
   http_geoip_module: "--with-http_geoip_module"
+  nginx_rtmp_module: "--add-module=/tmp/nginx-rtmp-module-{{nginx_rtmp_version}}"
 
 nginx_source_modules_excluded:
   - mail_pop3_module
@@ -171,3 +172,6 @@ nginx_ngx_pagespeed_version: 1.9.32.4
 
 # OpenSSL configuration
 openssl_version: "1.0.2h"
+
+# nginx_rtmp_module
+nginx_rtmp_version: "1.1.11"

--- a/tasks/modules.yml
+++ b/tasks/modules.yml
@@ -41,3 +41,6 @@
 
 - include: modules/http_geoip_module.yml
   when: nginx_source_modules_included.http_geoip_module is defined
+
+- include: modules/rtmp_module.yml
+  when: nginx_source_modules_included.nginx_rtmp_module is defined

--- a/tasks/modules/rtmp_module.yml
+++ b/tasks/modules/rtmp_module.yml
@@ -1,0 +1,26 @@
+# file: nginx/tasks/modules/rtmp_module.yml
+# configure flag: --add-module=/tmp/nginx-rtmp-module-{{nginx_rtmp_version}}
+
+- name: Nginx | Modules | Make sure nginx-rtmp-module dependencies are installed
+  apt:
+    pkg: "{{item}}"
+  with_items:
+    - libpcre3
+    - libpcre3-dev
+    - libssl-dev
+
+- name: Nginx | Modules | Gather nginx-rtmp-module tarball facts
+  stat: path=/tmp/nginx-rtmp-module-{{nginx_rtmp_version}}.tar.gz
+  register: nginx_rtmp_module_tarball
+
+- name: Nginx | Modules | Download the nginx-rtmp-module source
+  get_url:
+    url: "https://github.com/arut/nginx-rtmp-module/archive/v{{ nginx_rtmp_version }}.tar.gz"
+    dest: "/tmp/nginx-rtmp-module-{{nginx_rtmp_version}}.tar.gz"
+  when: not nginx_rtmp_module_tarball.stat.exists
+
+- name: Nginx | Modules | Unpack the nginx-rtmp-module source
+  command: tar -xvzf /tmp/nginx-rtmp-module-{{nginx_rtmp_version}}.tar.gz
+  args:
+    chdir: /tmp
+    creates: "/tmp/nginx-rtmp-module-{{nginx_rtmp_version}}"


### PR DESCRIPTION
The nginx rtmp installation guide can be found [here](https://github.com/arut/nginx-rtmp-module/wiki/Getting-started-with-nginx-rtmp).

Tested by running `vagrant up`.